### PR TITLE
Fix candidate answer formatting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 - Jest-based unit tests for core utilities
 
+## [0.0.5] - 2025-07-12
+
+### Fixed
+- Preserve Markdown formatting when inserting candidate answers
+
 
 ## [0.0.3] - 2025-07-11
 

--- a/main.ts
+++ b/main.ts
@@ -329,11 +329,13 @@ export default class InterviewerPlugin extends Plugin {
 										}
 										linesToRemove++;
 									}
-									currentLines.splice(answerLineIndex, linesToRemove, result);
-								} else {
-									// Add new answer after the question and ? marker
-									currentLines.splice(questionLineIndex + 2, 0, result);
-								}
+                                                                        const formatted = result.split('\n').map(l => `> ${l}`);
+                                                                        currentLines.splice(answerLineIndex, linesToRemove, '> @candidate', ...formatted, '');
+                                                                } else {
+                                                                        // Add new answer after the question and ? marker
+                                                                        const formatted = result.split('\n').map(l => `> ${l}`);
+                                                                        currentLines.splice(questionLineIndex + 2, 0, '> @candidate', ...formatted, '');
+                                                                }
 								
 								console.log('Updated lines:', currentLines.slice(questionLineIndex, questionLineIndex + 3));
 								await this.app.vault.modify(file, currentLines.join('\n'));
@@ -454,7 +456,8 @@ export default class InterviewerPlugin extends Plugin {
                                                                                 }
                                                                                 linesToRemove++;
                                                                         }
-                                                                        currentLines.splice(answerLineIndex, linesToRemove, '> @candidate', `> ${result}`);
+                                                                        const formatted = result.split('\n').map(l => `> ${l}`);
+                                                                        currentLines.splice(answerLineIndex, linesToRemove, '> @candidate', ...formatted, '');
                                                                 } else {
                                                                         // Add new answer after the canonical answer block
                                                                         let insertIndex = questionLineIndex;
@@ -466,7 +469,8 @@ export default class InterviewerPlugin extends Plugin {
                                                                                 }
                                                                                 insertIndex = j;
                                                                         }
-                                                                        currentLines.splice(insertIndex + 1, 0, '> @candidate', `> ${result}`);
+                                                                        const formatted = result.split('\n').map(l => `> ${l}`);
+                                                                        currentLines.splice(insertIndex + 1, 0, '> @candidate', ...formatted, '');
                                                                 }
 								
 								console.log('Updated lines:', currentLines.slice(questionLineIndex, questionLineIndex + 3));


### PR DESCRIPTION
## Summary
- preserve callout formatting when updating candidate answers
- add changelog entry

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870dcec43e4832fa2774552a2861fed