### PR TITLE
Fix candidate callout formatting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@
 ### Added
 - Jest-based unit tests for core utilities
 
+## [0.0.5] - 2025-07-12
+
+### Fixed
+- Preserve Markdown formatting when inserting candidate answers
+
+## [0.0.6] - 2025-07-12
+
+### Fixed
+- Ensure blank line between candidate answers and the next question
+
 
 ## [0.0.3] - 2025-07-11
 

--- a/main.ts
+++ b/main.ts
@@ -329,11 +329,13 @@ export default class InterviewerPlugin extends Plugin {
 										}
 										linesToRemove++;
 									}
-									currentLines.splice(answerLineIndex, linesToRemove, result);
-								} else {
-									// Add new answer after the question and ? marker
-									currentLines.splice(questionLineIndex + 2, 0, result);
-								}
+                                                                        const formatted = result.split('\n').map(l => `> ${l}`);
+                                                                        currentLines.splice(answerLineIndex, linesToRemove, '> @candidate', ...formatted, '>');
+                                                                } else {
+                                                                        // Add new answer after the question and ? marker
+                                                                        const formatted = result.split('\n').map(l => `> ${l}`);
+                                                                        currentLines.splice(questionLineIndex + 2, 0, '> @candidate', ...formatted, '>');
+                                                                }
 								
 								console.log('Updated lines:', currentLines.slice(questionLineIndex, questionLineIndex + 3));
 								await this.app.vault.modify(file, currentLines.join('\n'));
@@ -454,7 +456,8 @@ export default class InterviewerPlugin extends Plugin {
                                                                                 }
                                                                                 linesToRemove++;
                                                                         }
-                                                                        currentLines.splice(answerLineIndex, linesToRemove, '> @candidate', `> ${result}`);
+                                                                        const formatted = result.split('\n').map(l => `> ${l}`);
+                                                                        currentLines.splice(answerLineIndex, linesToRemove, '> @candidate', ...formatted, '>');
                                                                 } else {
                                                                         // Add new answer after the canonical answer block
                                                                         let insertIndex = questionLineIndex;
@@ -466,7 +469,8 @@ export default class InterviewerPlugin extends Plugin {
                                                                                 }
                                                                                 insertIndex = j;
                                                                         }
-                                                                        currentLines.splice(insertIndex + 1, 0, '> @candidate', `> ${result}`);
+                                                                        const formatted = result.split('\n').map(l => `> ${l}`);
+                                                                        currentLines.splice(insertIndex + 1, 0, '> @candidate', ...formatted, '>');
                                                                 }
 								
 								console.log('Updated lines:', currentLines.slice(questionLineIndex, questionLineIndex + 3));
@@ -736,9 +740,10 @@ export default class InterviewerPlugin extends Plugin {
 > ${answer}`;
 		
 		// Add candidate answer if it exists
-		if (candidateAnswer && candidateAnswer.trim() !== '') {
-			result += `\n> @candidate\n> ${candidateAnswer}`;
-		}
+                if (candidateAnswer && candidateAnswer.trim() !== '') {
+                        const formatted = candidateAnswer.split('\n').map(l => `> ${l}`).join('\n');
+                        result += `\n> @candidate\n${formatted}\n>`;
+                }
 		
 		return result;
 	}

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -40,7 +40,21 @@ describe('utility functions', () => {
       'medium'
     );
     expect(result).toBe(
-      '\n> [!question]- 🟡 Explain Git\n> Version control system.\n> @candidate\n> Candidate mentioned SVN too.'
+      '\n> [!question]- 🟡 Explain Git\n> Version control system.\n> @candidate\n> Candidate mentioned SVN too.\n>'
+    );
+  });
+
+  test('createInteractiveQuestion handles multiline candidate answer', () => {
+    const plugin: any = getPlugin();
+    const create = plugin['createInteractiveQuestion'] as any;
+    const result = create(
+      'Explain CI/CD',
+      'Continuous Integration and Deployment.',
+      'Line one.\nLine two.',
+      'medium'
+    );
+    expect(result).toBe(
+      '\n> [!question]- 🟡 Explain CI/CD\n> Continuous Integration and Deployment.\n> @candidate\n> Line one.\n> Line two.\n>'
     );
   });
 });


### PR DESCRIPTION
## Summary
- preserve blank line in candidate callouts
- handle multi-line candidate answers when generating questions
- test candidate formatting edge cases

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870dcec43e4832fa2774552a2861fed