### PR TITLE
Fix candidate answer spacing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,3 +37,8 @@
 
 ### Fixed
 - Preserve Markdown formatting when inserting candidate answers
+
+## [0.0.6] - 2025-07-11
+
+### Fixed
+- Prevent double blank lines when adding candidate answers to callout questions.

--- a/main.ts
+++ b/main.ts
@@ -333,8 +333,12 @@ export default class InterviewerPlugin extends Plugin {
                                                                         currentLines.splice(answerLineIndex, linesToRemove, '> @candidate', ...formatted, '');
                                                                 } else {
                                                                         // Add new answer after the question and ? marker
-                                                                        const formatted = result.split('\n').map(l => `> ${l}`);
-                                                                        currentLines.splice(questionLineIndex + 2, 0, '> @candidate', ...formatted, '');
+                                const formatted = result.split('\n').map(l => `> ${l}`);
+                                if (currentLines[questionLineIndex + 2]?.trim() === '') {
+                                        currentLines.splice(questionLineIndex + 2, 0, '> @candidate', ...formatted);
+                                } else {
+                                        currentLines.splice(questionLineIndex + 2, 0, '> @candidate', ...formatted, '');
+                                }
                                                                 }
 								
 								console.log('Updated lines:', currentLines.slice(questionLineIndex, questionLineIndex + 3));
@@ -469,8 +473,12 @@ export default class InterviewerPlugin extends Plugin {
                                                                                 }
                                                                                 insertIndex = j;
                                                                         }
-                                                                        const formatted = result.split('\n').map(l => `> ${l}`);
-                                                                        currentLines.splice(insertIndex + 1, 0, '> @candidate', ...formatted, '');
+                                const formatted = result.split('\n').map(l => `> ${l}`);
+                                if (currentLines[insertIndex + 1]?.trim() === '') {
+                                        currentLines.splice(insertIndex + 1, 0, '> @candidate', ...formatted);
+                                } else {
+                                        currentLines.splice(insertIndex + 1, 0, '> @candidate', ...formatted, '');
+                                }
                                                                 }
 								
 								console.log('Updated lines:', currentLines.slice(questionLineIndex, questionLineIndex + 3));


### PR DESCRIPTION
## Summary
- avoid inserting candidate lines after a blank line in callout mode
- keep existing blank line when adding answers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870f098a754832fa5fa02f07fdc33a3